### PR TITLE
Change display name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-conbee-adapter",
-  "display_name": "Zigbee (ConBee USB stick)",
+  "display_name": "Zigbee (via deCONZ REST API)",
   "version": "0.9.5",
   "description": "Uses deCONZ REST API to manage ConBee USB stick. Check https://github.com/tomasy/zigbee-conbee-adapter ",
   "author": "tomasy",


### PR DESCRIPTION
Now that the official Zigbee adapter supports the Conbee dongle,
the naming of this adapter is a bit confusing. This new name
should make things more clear.